### PR TITLE
fix LogsCollector.php to play nice with daily logs naming convention in ...

### DIFF
--- a/src/DataCollector/LogsCollector.php
+++ b/src/DataCollector/LogsCollector.php
@@ -24,12 +24,12 @@ class LogsCollector extends MessagesCollector
      */
     public function getLogsFile()
     {
-        //Default log location (single file)
-        $path = storage_path() . '/logs/laravel.log';
+        // default daily rotating logs (Laravel 5.0)
+        $path = storage_path() . '/logs/laravel-' . date('Y-m-d') . '.log';
 
-        //Rotating logs (Laravel 4.0)
+        // single file logs
         if (!file_exists($path)) {
-            $path = storage_path() . '/logs/log-' . php_sapi_name() . '-' . date('Y-m-d') . '.txt';
+            $path = storage_path() . '/logs/laravel.log';
         }
 
         return $path;


### PR DESCRIPTION
Laravel 5 defaults to daily log files with the naming convention laravel-2015-04-08.log. updated getLogsFile() method to play nice with this change and default to the daily logs while falling back to the single file logs.
